### PR TITLE
Revert "Updates to handle PTMs"

### DIFF
--- a/af_pipeline/Parser.py
+++ b/af_pipeline/Parser.py
@@ -183,8 +183,8 @@ class DataParser:
             with open(self.data_file_path, "r") as f:
                 data = json.load(f)
 
-            if isinstance(data, list):
-                data = data[0]
+        if isinstance(data, list):
+            data = data[0]
 
         else:
             raise Exception("Incorrect file format.. Suported .pkl/.json only.")
@@ -299,33 +299,12 @@ class DataParser:
         # For AF3.
         elif "pae" in data:
             pae = np.array(data["pae"])
-        
+
         else:
             raise Exception("PAE matrix not found...")
 
         return pae
-    
-    def get_modified_pae(self, data:Dict):
-        """
-        Returns the modified PAE matrix in case of PTMs,
-        else the original PAE matrix.
-        """
-        pae = self.get_pae(data)
-        token_res_ids = self.get_token_res_ids(data)
 
-        diffs = np.ediff1d(token_res_ids) # If the diffs is 0, there are consecutive values
-        boundaries = np.concatenate(([0], (np.where(diffs != 0)[0] + 1), [len(token_res_ids)])) 
-
-        # Collect ranges where repetition length is >= 2
-        for start, end in zip(boundaries[:-1], boundaries[1:]):
-            if end - start >= 2:
-                mean_value = np.round(np.mean(pae[start:end, start:end]), 2)
-                pae[start, start] = mean_value  # Set the pae value to mean value
-                indices_to_remove = (range(start + 1, end))
-                pae = np.delete(np.delete(pae, indices_to_remove, axis=0), indices_to_remove, axis=1)
-        
-        return pae
-    
     def get_avg_pae(self, pae: np.ndarray):
         """
         Return the average PAE matrix. \n

--- a/af_pipeline/_Initialize.py
+++ b/af_pipeline/_Initialize.py
@@ -41,10 +41,10 @@ class _Initialize(AfParser):
         """
 
         data = self.dataparser.get_data_dict()
-        self.pae = self.dataparser.get_modified_pae(data=data)
+        self.pae = self.dataparser.get_pae(data=data)
         self.avg_pae = self.dataparser.get_avg_pae(pae=self.pae)
         self.contact_probs_mat = self.dataparser.get_contact_probs_mat(data=data)
-        if self.contact_probs_mat is not None:
+        if self.contact_probs_mat:
             self.avg_contact_probs_mat = self.dataparser.get_avg_contact_probs_mat(contact_probs_mat=self.contact_probs_mat)
 
         if self.struct_file_path:

--- a/af_pipeline/pae_to_domains/pae_to_domains.py
+++ b/af_pipeline/pae_to_domains/pae_to_domains.py
@@ -27,21 +27,6 @@ def parse_pae_file(pae_file):
     if 'pae' in data:
         # AF3
         matrix = numpy.array(data['pae'], dtype=numpy.float64)
-        token_res_ids = numpy.array(data['token_res_ids'], dtype=numpy.float64)
-
-        diffs = numpy.ediff1d(token_res_ids) # If the diffs is 0, there are consecutive values
-        boundaries = numpy.concatenate(([0], (numpy.where(diffs != 0)[0] + 1), [len(token_res_ids)])) 
-        indices_to_remove = []
-
-        # Collect ranges where repetition length is >= 2
-        for start, end in zip(boundaries[:-1], boundaries[1:]):
-            if end - start >= 2:
-                mean_value = numpy.round(numpy.mean(matrix[start:end, start:end]), 2)
-                matrix[start:end, start:end] = mean_value  # Set the matrix value to mean value
-                indices_to_remove.extend(range(start + 1, end))
-        
-        matrix = numpy.delete(numpy.delete(matrix, indices_to_remove, axis=0), indices_to_remove, axis=1)
-
     elif "predicted_aligned_error" in data:
         # AF2
         matrix = numpy.array(data["predicted_aligned_error"], dtype=numpy.float64)


### PR DESCRIPTION
Reverts isblab/IMP_Toolbox#57

Address bugs:
- [ ] only PAE<sub>i,i</sub>  is getting replaced, need to address the PAE<sub>i,j</sub> values properly.
- [ ] Changes not made in `Parser.py` but in `pae_to_domains.py` instead. `parse_pae_file` function in `pae_to_domains.py` should be deleted.
- [ ] Test on the example `Lb2Cas12a_RNA_DNA_complex` in the examples directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the process for handling PAE matrices by removing logic that averaged and collapsed repeated residue indices.
  - Updated internal methods to streamline data extraction and matrix handling.
- **Bug Fixes**
  - Ensured consistent data parsing across different file types for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->